### PR TITLE
Enhance search to include albums and tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cmdk": "1.0.0",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.5.2",
+    "fuse.js": "^7.1.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.474.0",
     "next": "15.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.5.2
         version: 8.5.2(react@19.0.0)
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1958,6 +1961,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
@@ -4838,6 +4845,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.1.0: {}
 
   get-intrinsic@1.2.7:
     dependencies:

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,17 +1,9 @@
 import { Suspense } from 'react'
 
-import { TracksTable } from '@/components/tracks-table'
+import { SearchResultsClient } from '@/components/search-results-client'
 import { getLibrary } from '../actions'
 
 type SearchParams = Promise<{ q: string | undefined }>
-
-function NoResults({ query }: { query: string }) {
-  return (
-    <div className="flex items-center justify-center h-full text-gray-500 dark:text-gray-400">
-      No results found for &apos;{query}&apos; in your library
-    </div>
-  )
-}
 
 function NoQuery() {
   return (
@@ -24,15 +16,7 @@ function NoQuery() {
 async function SearchResults({ query }: { query: string }) {
   const library = await getLibrary()
 
-  const results = Object.values(library.tracks).filter((track) =>
-    track.title?.toLowerCase().includes(query.toLowerCase())
-  )
-
-  if (results.length === 0) {
-    return <NoResults query={query} />
-  }
-
-  return <TracksTable tracks={results} albums={library.albums} />
+  return <SearchResultsClient library={library} query={query} />
 }
 
 export default async function SearchPage(props: {

--- a/src/components/search-albums-section.tsx
+++ b/src/components/search-albums-section.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import type { Album } from '@/app/actions'
+
+interface SearchAlbumsSectionProps {
+  albums: Album[]
+  query: string
+}
+
+export function SearchAlbumsSection({ albums, query }: SearchAlbumsSectionProps) {
+  if (albums.length === 0) {
+    return (
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold mb-4">Albums</h2>
+        <p className="text-gray-500 dark:text-gray-400">
+          No albums found for &apos;{query}&apos;
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold mb-4">
+        Albums ({albums.length} found)
+      </h2>
+      
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-3 md:gap-4">
+        {albums.map((album) => (
+          <Link href={`/albums/${album.id}`} key={album.id} className="group">
+            <div className="cursor-pointer transition-all duration-200 hover:bg-gray-50/50 dark:hover:bg-gray-800/50 rounded-lg p-2 md:p-3 -m-2 md:-m-3">
+              <div className="space-y-2 md:space-y-3">
+                {/* Album artwork */}
+                <div className="relative w-full aspect-square rounded-md md:rounded-lg overflow-hidden shadow-md group-hover:shadow-xl transition-all duration-200 group-hover:scale-105">
+                  <Image
+                    src={album?.artwork_url || '/images/unknown-album.png'}
+                    alt={album.name}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, (max-width: 1280px) 20vw, 12vw"
+                  />
+
+                  {/* Hover overlay with play button effect */}
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-all duration-200 flex items-center justify-center opacity-0 group-hover:opacity-100">
+                    <div className="w-8 h-8 md:w-10 md:h-10 bg-primary rounded-full flex items-center justify-center shadow-lg transform scale-90 group-hover:scale-100 transition-transform duration-200">
+                      <svg
+                        className="w-3 h-3 md:w-4 md:h-4 text-primary-foreground ml-0.5"
+                        fill="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path d="M8 5v14l11-7z" />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Album info */}
+                <div className="space-y-0.5 md:space-y-1 min-h-0">
+                  <h3 className="font-medium text-sm leading-tight truncate group-hover:text-primary transition-colors duration-200">
+                    {album.name}
+                  </h3>
+                  <p className="text-xs text-muted-foreground/80 truncate">
+                    {album.tracks?.length ? `${album.tracks.length} tracks` : 'Album'}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/search-results-client.tsx
+++ b/src/components/search-results-client.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { SearchTracksSection } from '@/components/search-tracks-section'
+import { SearchAlbumsSection } from '@/components/search-albums-section'
+import { useSearch } from '@/hooks/use-search'
+import type { Library } from '@/app/actions'
+
+interface SearchResultsClientProps {
+  library: Library
+  query: string
+}
+
+function NoResults({ query }: { query: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-500 dark:text-gray-400">
+      No results found for &apos;{query}&apos; in your library
+    </div>
+  )
+}
+
+export function SearchResultsClient({ library, query }: SearchResultsClientProps) {
+  const { tracks, albums } = useSearch(library, query)
+
+  const hasResults = tracks.length > 0 || albums.length > 0
+
+  if (!hasResults) {
+    return <NoResults query={query} />
+  }
+
+  return (
+    <div className="space-y-8">
+      <SearchAlbumsSection albums={albums} query={query} />
+      <SearchTracksSection tracks={tracks} albums={library.albums} query={query} />
+    </div>
+  )
+}

--- a/src/components/search-tracks-section.tsx
+++ b/src/components/search-tracks-section.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+import { TracksTable } from '@/components/tracks-table'
+import { Button } from '@/components/ui/button'
+import type { Track, Album } from '@/app/actions'
+
+interface SearchTracksSectionProps {
+  tracks: Track[]
+  albums: Record<string, Album>
+  query: string
+}
+
+export function SearchTracksSection({ tracks, albums, query }: SearchTracksSectionProps) {
+  const [displayCount, setDisplayCount] = useState(10)
+  
+  const displayedTracks = tracks.slice(0, displayCount)
+  const hasMore = tracks.length > displayCount
+
+  const handleSeeMore = () => {
+    setDisplayCount(prev => prev + 10)
+  }
+
+  if (tracks.length === 0) {
+    return (
+      <div className="mb-8">
+        <h2 className="text-lg font-semibold mb-4">Tracks</h2>
+        <p className="text-gray-500 dark:text-gray-400">
+          No tracks found for &apos;{query}&apos;
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold mb-4">
+        Tracks ({tracks.length} found)
+      </h2>
+      
+      <TracksTable tracks={displayedTracks} albums={albums} />
+      
+      {hasMore && (
+        <div className="mt-4 flex justify-center">
+          <Button 
+            variant="outline" 
+            onClick={handleSeeMore}
+            className="px-6"
+          >
+            See More ({Math.min(10, tracks.length - displayCount)} more)
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -1,0 +1,90 @@
+import { useMemo } from 'react'
+import Fuse from 'fuse.js'
+import type { Track, Album, Library } from '@/app/actions'
+
+export type SearchResult = {
+  tracks: Track[]
+  albums: Album[]
+}
+
+export function useSearch(library: Library, query: string): SearchResult {
+  const searchResult = useMemo(() => {
+    if (!query.trim()) {
+      return { tracks: [], albums: [] }
+    }
+
+    // Prepare tracks data for search
+    const tracksData = Object.values(library.tracks).map((track: Track) => ({
+      ...track,
+      albumName: library.albums[track.albumId]?.name || '',
+    }))
+
+    // Prepare albums data for search
+    const albumsData = Object.values(library.albums)
+
+    // Configure Fuse.js for tracks
+    const tracksFuse = new Fuse(tracksData, {
+      keys: [
+        { name: 'title', weight: 0.7 },
+        { name: 'albumName', weight: 0.3 }
+      ],
+      threshold: 0.4, // Allow some fuzziness
+      includeScore: true,
+      includeMatches: true,
+      minMatchCharLength: 2,
+    })
+
+    // Configure Fuse.js for albums
+    const albumsFuse = new Fuse(albumsData, {
+      keys: [
+        { name: 'name', weight: 1.0 }
+      ],
+      threshold: 0.4,
+      includeScore: true,
+      includeMatches: true,
+      minMatchCharLength: 2,
+    })
+
+    // Perform searches
+    const trackResults = tracksFuse.search(query)
+    const albumResults = albumsFuse.search(query)
+
+    // Extract items from Fuse.js results
+    const tracks = trackResults.map(result => {
+      const { albumName, ...track } = result.item as Track & { albumName: string }
+      return track as Track
+    })
+
+    const albums = albumResults.map(result => result.item as Album)
+
+    // Also include albums that contain matching tracks
+    const albumsFromTracks = new Set<string>()
+    tracks.forEach(track => {
+      if (track.albumId && library.albums[track.albumId]) {
+        albumsFromTracks.add(track.albumId)
+      }
+    })
+
+    // Merge album results with albums from track matches
+    const allAlbums = new Map<string, Album>()
+    
+    // Add direct album matches
+    albums.forEach(album => {
+      allAlbums.set(album.id, album)
+    })
+
+    // Add albums from track matches
+    albumsFromTracks.forEach(albumId => {
+      if (library.albums[albumId]) {
+        allAlbums.set(albumId, library.albums[albumId])
+      }
+    })
+
+    return {
+      tracks,
+      albums: Array.from(allAlbums.values())
+    }
+  }, [library, query])
+
+  return searchResult
+}


### PR DESCRIPTION
Implement fuzzy search across tracks and albums, including pagination for track results and a dedicated section for album matches.

---
<a href="https://cursor.com/background-agent?bcId=bc-67c58abc-4c9e-4fb0-be22-0eb11c24a984">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67c58abc-4c9e-4fb0-be22-0eb11c24a984">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

